### PR TITLE
Readds the stimball reaction

### DIFF
--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -27,3 +27,13 @@
 /atom/proc/fire_nuclear_particle(angle = rand(0,360)) //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
 	var/obj/projectile/energy/nuclear_particle/P = new /obj/projectile/energy/nuclear_particle(src)
 	P.fire(angle)
+
+/obj/projectile/energy/nuclear_particle/cellular
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	irradiate = 0
+	damage_type = CLONE
+	damage = 20
+
+/atom/proc/fire_nuclear_particle_cell(angle = rand(0,360)) //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
+	var/obj/projectile/energy/nuclear_particle/cellular/P = new /obj/projectile/energy/nuclear_particle/cellular(src)
+	P.fire(angle)


### PR DESCRIPTION
### About the pull request
Pseudo-port of Yog's improved stimballs. Rebalanced it to better suit the increased stimulum production rate from HFR and to use slightly fancier math.
This reaction produces a radball that does not deal radiation but cellular damage, still armorflagged as RAD.

### Why is it good for the game?
More content for atmos players; more usage for stimulum; a slightly more in depth reaction to our boring roster.

### Changelog
🆑
add: Adds stimball reaction
/🆑
